### PR TITLE
ci: Replace deprecated set-output with GITHUB_OUTPUT file

### DIFF
--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -23,8 +23,8 @@ jobs:
       id: config
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-        echo "::set-output name=repository::${repo}"
-        echo "::set-output name=target_env::production"
+        echo "repository=${repo}" >> "$GITHUB_OUTPUT"
+        echo "target_env=production" >> "$GITHUB_OUTPUT"
 
     - name: StormForger | Install forge CLI
       run: |


### PR DESCRIPTION
Our current usage of set-output is deprecated, instead one should the `$GITHUB_OUTPUT` env variable.

See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter